### PR TITLE
120119 sh fix jacococ bug

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,12 +61,12 @@
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>
     </dependency>
-<!--    <dependency>-->
-<!--      <groupId>org.junit.jupiter</groupId>-->
-<!--      <artifactId>junit-jupiter</artifactId>-->
-<!--      <version>RELEASE</version>-->
-<!--      <scope>test</scope>-->
-<!--    </dependency>-->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>RELEASE</version>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-netflix-eureka-client</artifactId>
-      <version>2.1.2.RELEASE</version>
+      <version>2.1.3.RELEASE</version>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.springframework.cloud/spring-cloud-starter-netflix-ribbon -->
     <dependency>
@@ -61,12 +61,12 @@
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>RELEASE</version>
-      <scope>test</scope>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>org.junit.jupiter</groupId>-->
+<!--      <artifactId>junit-jupiter</artifactId>-->
+<!--      <version>RELEASE</version>-->
+<!--      <scope>test</scope>-->
+<!--    </dependency>-->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -77,11 +77,11 @@
       <artifactId>jaxb-api</artifactId>
       <version>2.3.0</version>
     </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-data-jpa</artifactId>
-      <scope>compile</scope>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>org.springframework.boot</groupId>-->
+<!--      <artifactId>spring-boot-starter-data-jpa</artifactId>-->
+<!--      <scope>compile</scope>-->
+<!--    </dependency>-->
     <!-- swagger dependencies -->
     <dependency>
       <groupId>io.springfox</groupId>
@@ -137,7 +137,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.2</version>
+        <version>2.19.1</version>
       </plugin>
       <plugin>
         <groupId>org.jacoco</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -28,12 +28,12 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>org.junit.vintage</groupId>
-          <artifactId>junit-vintage-engine</artifactId>
-        </exclusion>
-      </exclusions>
+<!--      <exclusions>-->
+<!--        <exclusion>-->
+<!--          <groupId>org.junit.vintage</groupId>-->
+<!--          <artifactId>junit-vintage-engine</artifactId>-->
+<!--        </exclusion>-->
+<!--      </exclusions>-->
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -61,12 +61,12 @@
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <version>RELEASE</version>
-      <scope>test</scope>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>org.junit.jupiter</groupId>-->
+<!--      <artifactId>junit-jupiter</artifactId>-->
+<!--      <version>RELEASE</version>-->
+<!--      <scope>test</scope>-->
+<!--    </dependency>-->
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.1.5.RELEASE</version>
+    <version>2.1.7.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.example</groupId>

--- a/src/test/java/com/example/postsapi/PostsApiApplicationTests.java
+++ b/src/test/java/com/example/postsapi/PostsApiApplicationTests.java
@@ -1,13 +1,14 @@
 package com.example.postsapi;
 
-//import org.junit.jupiter.api.Test;
+//import org.junits.jupiter.api.Test;
+import org.junit.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class PostsApiApplicationTests {
-//
-//	@Test
-//	void contextLoads() {
-//	}
+
+	@Test
+	void contextLoads() {
+	}
 
 }

--- a/src/test/java/com/example/postsapi/PostsApiApplicationTests.java
+++ b/src/test/java/com/example/postsapi/PostsApiApplicationTests.java
@@ -1,13 +1,13 @@
 package com.example.postsapi;
 
-import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
 class PostsApiApplicationTests {
-
-	@Test
-	void contextLoads() {
-	}
+//
+//	@Test
+//	void contextLoads() {
+//	}
 
 }


### PR DESCRIPTION
Deliverables:
- Jacoco correctly picking up tests
- Pom.xml changes
  - spring-boot-starter-parent 2.1.5 -> 2.1.7
  - remove junit-vintage-engine exclusion
  - spring-cloud-starter-netflix-eureka-client 2.1.2 -> 2.1.3
  - remove junit-jupiter dependency
  - remove redundant spring-boot-starter-data-jpa
  - maven-surefire-plugin 2.22.2 -> 2.19.1
- PostApiApplication.java changes
  - import org.junit.Test instead of org.junits.jupiter.api.Test