### PR TITLE
init/config rabbitMq for posts to send CascaseDeleteComment kickoff

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,19 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework.amqp</groupId>
+      <artifactId>spring-rabbit-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-amqp</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.amqp</groupId>
+      <artifactId>spring-amqp</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/src/main/java/com/example/postsapi/config/RabbitMQConfig.java
+++ b/src/main/java/com/example/postsapi/config/RabbitMQConfig.java
@@ -1,0 +1,17 @@
+
+package com.example.postsapi.config;
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    private final static String QUEUE_NAME = "queue1";
+
+    @Bean
+    public Queue queue() {
+        return new Queue(QUEUE_NAME, false, false ,false);
+    }
+}

--- a/src/main/java/com/example/postsapi/mq/Sender.java
+++ b/src/main/java/com/example/postsapi/mq/Sender.java
@@ -1,0 +1,27 @@
+package com.example.postsapi.mq;
+
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class Sender {
+    @Autowired
+    RabbitTemplate rabbitTemplate;
+
+    @Autowired
+    Queue queue;
+
+    public void send(String message) {
+        System.out.println("Sending message...");
+        rabbitTemplate.convertAndSend(queue.getName(), message);
+        System.out.println("Message sent: " + message + " on q: " + queue.getName());
+    }
+
+    public void sendPostId(String postId) {
+        // TODO: how to specify consumer?
+        rabbitTemplate.convertAndSend(queue.getName(), postId);
+        System.out.println("PostId sent: " + postId + " on q: " + queue.getName());
+    }
+}

--- a/src/main/java/com/example/postsapi/mq/Sender.java
+++ b/src/main/java/com/example/postsapi/mq/Sender.java
@@ -13,12 +13,6 @@ public class Sender {
     @Autowired
     Queue queue;
 
-    public void send(String message) {
-        System.out.println("Sending message...");
-        rabbitTemplate.convertAndSend(queue.getName(), message);
-        System.out.println("Message sent: " + message + " on q: " + queue.getName());
-    }
-
     public void sendPostId(String postId) {
         // TODO: how to specify consumer?
         rabbitTemplate.convertAndSend(queue.getName(), postId);

--- a/src/main/java/com/example/postsapi/service/PostServiceImpl.java
+++ b/src/main/java/com/example/postsapi/service/PostServiceImpl.java
@@ -8,6 +8,7 @@ import com.example.postsapi.exceptionhandler.UserNotFoundException;
 import com.example.postsapi.feign.CommentClient;
 import com.example.postsapi.feign.UserClient;
 import com.example.postsapi.model.Post;
+import com.example.postsapi.mq.Sender;
 import com.example.postsapi.repository.PostRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -26,6 +27,9 @@ public class PostServiceImpl implements PostService {
     @Autowired
     CommentClient commentClient;
 
+    @Autowired
+    Sender sender;
+
     @Override
     public Post createPost(Post newPost, int userId) throws NoPostTitleException {
         if(newPost.getTitle().trim().length() > 0) {
@@ -42,7 +46,7 @@ public class PostServiceImpl implements PostService {
             throw new PostNotFoundException("The post cannot be deleted. No post of post Id: " + postId + " exists.");
 
         postRepository.deleteById(postId);
-        commentClient.deleteCommmentsByPostId(postId);
+        sender.sendPostId(String.valueOf(postId));
         return "post: " + postId + " successfully deleted";
        // TODO: how to sort out void response to check if post successfully deleted
     }

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -14,3 +14,9 @@ spring.datasource.password=password
 
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
 spring.resources.add-mappings=true
+
+spring.rabbitmq.host=rabbitmq
+spring.rabbitmq.port=5672
+spring.rabbitmq.username=guest
+spring.rabbitmq.password=guest
+spring.rabbitmq.dynamic=true


### PR DESCRIPTION
Re-did RabbitMQ on posts-api to send a message to queue1.
 - configuration in app.properties that got lost in the great parting of the git seas
 - the message contains a string of the postId reference for deleting comments (consumer)